### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test
+      - run: rm -rf node_modules
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v1
+        id: deployment
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This project demonstrates a simple spatial acoustics simulation in the browser using the Web Audio API.
 
 Open `index.html` in a modern browser or run `npm start` to serve the page with a local HTTP server.
+
+The site is also deployed automatically to **GitHub Pages** using the workflow
+defined in `.github/workflows/deploy.yml`. After pushing to the `main` branch
+the latest version will be available from the repository's Pages URL.
+


### PR DESCRIPTION
## Summary
- deploy the site on GitHub Pages using GitHub Actions
- mention Pages deployment in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415405bee8832d92523811f7567f74